### PR TITLE
fix: Improve logging and JSON error handling

### DIFF
--- a/Web/Services/ColetaService.cs
+++ b/Web/Services/ColetaService.cs
@@ -64,10 +64,22 @@ namespace Web.Services
                         int bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length);
                         string resposta = Encoding.UTF8.GetString(buffer, 0, bytesRead);
 
-                        var hardwareInfo = JsonSerializer.Deserialize<HardwareInfo>(resposta);
+                        HardwareInfo hardwareInfo;
+                        try
+                        {
+                            hardwareInfo = JsonSerializer.Deserialize<HardwareInfo>(resposta);
+                        }
+                        catch (JsonException jsonEx)
+                        {
+                            string message = $"Erro de JSON ao coletar dados de {computadorIp}: {jsonEx.Message}. Resposta recebida: '{resposta}'";
+                            _logService.AddLog("Error", message, "Coleta");
+                            onResult(message);
+                            return;
+                        }
+
                         if (hardwareInfo == null || hardwareInfo.MAC == null)
                         {
-                            string message = $"Falha ao deserializar a resposta ou MAC é nulo para o IP: {computadorIp}. Resposta: {resposta}";
+                            string message = $"Resposta JSON recebida, mas o MAC é nulo para o IP: {computadorIp}. Resposta: {resposta}";
                             _logService.AddLog("Error", message, "Coleta");
                             onResult(message);
                             return;


### PR DESCRIPTION
This commit addresses two issues reported by the user:

1.  Improves logging for the 'Send Commands' feature by adding a continuation to the background tasks to catch and log any exceptions that occur during their execution.

2.  Improves error handling for data collection by adding a specific try-catch block for `JsonException`. If the collection agent returns a non-JSON response, the raw response is now logged to help diagnose the agent's behavior.