### PR TITLE
fix: Correct typo in DisplayFor helper method call

### DIFF
--- a/Web/Views/Computadores/Index.cshtml
+++ b/Web/Views/Computadores/Index.cshtml
@@ -113,7 +113,7 @@
                     <td class="col-processadorfabricante">@Html.DisplayFor(modelItem => item.ProcessadorFabricante)</td>
                     <td class="col-processadorcore">@Html.DisplayFor(modelItem => item.ProcessadorCore)</td>
                     <td class="col-processadorthread">@Html.DisplayFor(modelItem => item.ProcessadorThread)</td>
-                    <td class="col-processadorclock">@Html.Displayfor(modelItem => item.ProcessadorClock)</td>
+                    <td class="col-processadorclock">@Html.DisplayFor(modelItem => item.ProcessadorClock)</td>
                     <td class="col-ram">@Html.DisplayFor(modelItem => item.Ram)</td>
                     <td class="col-ramtipo">@Html.DisplayFor(modelItem => item.RamTipo)</td>
                     <td class="col-ramvelocidade">@Html.DisplayFor(modelItem => item.RamVelocidade)</td>


### PR DESCRIPTION
This commit fixes a build error (CS1061) in `Web/Views/Computadores/Index.cshtml` caused by a typo in a Razor helper method. `@Html.Displayfor` has been corrected to `@Html.DisplayFor`.