### PR TITLE
fix: Add debug logging to Comandos action

### DIFF
--- a/Web/Controllers/GerenciamentoController.cs
+++ b/Web/Controllers/GerenciamentoController.cs
@@ -202,6 +202,7 @@ namespace Web.Controllers
         [ValidateAntiForgeryToken]
         public IActionResult Comandos(ComandoViewModel model)
         {
+            _logService.AddLog("Debug", $"Ação Comandos recebida. Tipo: {model.TipoEnvio}, IP: {model.IpAddress}, Range: {model.IpRange}, Comando: {model.Comando}", "Sistema");
             model.ComandoIniciado = true;
 
             if (!ModelState.IsValid)


### PR DESCRIPTION
To diagnose why remote commands are reportedly not being logged, this commit adds a new 'Debug' level log entry at the very beginning of the `Comandos` action in `GerenciamentoController`. This will help determine if the LogService is being called correctly from the controller's context before the background task is initiated.