### PR TITLE
hotfix: Correct Delete action method signature

### DIFF
--- a/Web/Controllers/ComputadoresController.cs
+++ b/Web/Controllers/ComputadoresController.cs
@@ -355,7 +355,7 @@ namespace Web.Controllers
         // POST: Computadores/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
-        public IActionResult Delete(string id)
+        public IActionResult DeleteConfirmed(string id)
         {
             try
             {


### PR DESCRIPTION
This commit fixes a build error (CS0111) in `ComputadoresController.cs` caused by two methods having the same name and signature (`Delete(string id)`). The POST action has been renamed back to `DeleteConfirmed(string id)` and decorated with `[ActionName("Delete")]` to resolve the C# compiler error while maintaining the correct routing for the form post.