### PR TITLE
feat: Add persistent logging for user and computer changes

### DIFF
--- a/Web/Controllers/ComputadoresController.cs
+++ b/Web/Controllers/ComputadoresController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
+using Web.Services;
 
 namespace Web.Controllers
 {
@@ -16,11 +17,13 @@ namespace Web.Controllers
     {
         private readonly string _connectionString;
         private readonly ILogger<ComputadoresController> _logger;
+        private readonly PersistentLogService _persistentLogService;
 
-        public ComputadoresController(IConfiguration configuration, ILogger<ComputadoresController> logger)
+        public ComputadoresController(IConfiguration configuration, ILogger<ComputadoresController> logger, PersistentLogService persistentLogService)
         {
             _connectionString = configuration.GetConnectionString("DefaultConnection");
             _logger = logger;
+            _persistentLogService = persistentLogService;
         }
 
         public IActionResult Index(string sortOrder, string searchString,
@@ -248,6 +251,7 @@ namespace Web.Controllers
                             cmd.ExecuteNonQuery();
                         }
                     }
+                    _persistentLogService.AddLog("Computer", "Create", User.Identity.Name, $"Computer '{viewModel.MAC}' created.");
                     return RedirectToAction(nameof(Index));
                 }
                 catch (Exception ex)
@@ -356,6 +360,7 @@ namespace Web.Controllers
                             cmd.ExecuteNonQuery();
                         }
                     }
+                    _persistentLogService.AddLog("Computer", "Update", User.Identity.Name, $"Computer '{viewModel.MAC}' updated.");
                     return RedirectToAction(nameof(Index));
                 }
                 catch (Exception ex)
@@ -407,6 +412,7 @@ namespace Web.Controllers
                         cmd.ExecuteNonQuery();
                     }
                 }
+                _persistentLogService.AddLog("Computer", "Delete", User.Identity.Name, $"Computer '{id}' deleted.");
                 return RedirectToAction(nameof(Index));
             }
             catch (Exception ex)

--- a/Web/Controllers/GerenciamentoController.cs
+++ b/Web/Controllers/GerenciamentoController.cs
@@ -17,12 +17,14 @@ namespace Web.Controllers
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly ILogger<GerenciamentoController> _logger;
         private readonly IConfiguration _configuration;
+        private readonly PersistentLogService _persistentLogService;
         
-        public GerenciamentoController(IServiceScopeFactory scopeFactory, ILogger<GerenciamentoController> logger, IConfiguration configuration)
+        public GerenciamentoController(IServiceScopeFactory scopeFactory, ILogger<GerenciamentoController> logger, IConfiguration configuration, PersistentLogService persistentLogService)
         {
             _scopeFactory = scopeFactory;
             _logger = logger;
             _configuration = configuration;
+            _persistentLogService = persistentLogService;
         }
 
         // GET: /Gerenciamento/Logs
@@ -159,6 +161,18 @@ namespace Web.Controllers
         public IActionResult Index()
         {
             return View();
+        }
+
+        public IActionResult PersistentLogs(string entityTypeFilter, string actionTypeFilter)
+        {
+            var logs = _persistentLogService.GetLogs(entityTypeFilter, actionTypeFilter);
+            var viewModel = new PersistentLogViewModel
+            {
+                Logs = logs,
+                EntityTypeFilter = entityTypeFilter,
+                ActionTypeFilter = actionTypeFilter
+            };
+            return View(viewModel);
         }
 
         // GET: /Gerenciamento/Coletar

--- a/Web/Models/PersistentLog.cs
+++ b/Web/Models/PersistentLog.cs
@@ -1,0 +1,28 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace web.Models
+{
+    public class PersistentLog
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        public DateTime Timestamp { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public string EntityType { get; set; } // "User" or "Computer"
+
+        [Required]
+        [MaxLength(50)]
+        public string ActionType { get; set; } // "Create", "Update", "Delete"
+
+        [Required]
+        [MaxLength(255)]
+        public string PerformedBy { get; set; }
+
+        public string Details { get; set; }
+    }
+}

--- a/Web/Models/PersistentLogViewModel.cs
+++ b/Web/Models/PersistentLogViewModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace web.Models
+{
+    public class PersistentLogViewModel
+    {
+        public List<PersistentLog> Logs { get; set; }
+        public string EntityTypeFilter { get; set; }
+        public string ActionTypeFilter { get; set; }
+    }
+}

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -18,10 +18,13 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("Admin", policy => policy.RequireRole("Admin"));
 });
 
+using Web.Services;
+
 builder.Services.AddScoped<ColetaService>();
 builder.Services.AddScoped<LogService>();
 builder.Services.AddScoped<ComandoService>();
 builder.Services.AddScoped<UserService>();
+builder.Services.AddScoped<PersistentLogService>();
 
 // Configuração do Kestrel para escutar em todas as interfaces de rede
 builder.WebHost.ConfigureKestrel(serverOptions =>

--- a/Web/Services/PersistentLogService.cs
+++ b/Web/Services/PersistentLogService.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using web.Models;
+
+namespace Web.Services
+{
+    public class PersistentLogService
+    {
+        private readonly string _connectionString;
+
+        public PersistentLogService(IConfiguration configuration)
+        {
+            _connectionString = configuration.GetConnectionString("DefaultConnection");
+        }
+
+        public void AddLog(string entityType, string actionType, string performedBy, string details)
+        {
+            using (SqlConnection connection = new SqlConnection(_connectionString))
+            {
+                connection.Open();
+                string sql = "INSERT INTO PersistentLogs (Timestamp, EntityType, ActionType, PerformedBy, Details) VALUES (@Timestamp, @EntityType, @ActionType, @PerformedBy, @Details)";
+                using (SqlCommand cmd = new SqlCommand(sql, connection))
+                {
+                    cmd.Parameters.AddWithValue("@Timestamp", DateTime.Now);
+                    cmd.Parameters.AddWithValue("@EntityType", entityType);
+                    cmd.Parameters.AddWithValue("@ActionType", actionType);
+                    cmd.Parameters.AddWithValue("@PerformedBy", performedBy);
+                    cmd.Parameters.AddWithValue("@Details", (object)details ?? DBNull.Value);
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public List<PersistentLog> GetLogs(string entityTypeFilter, string actionTypeFilter)
+        {
+            var logs = new List<PersistentLog>();
+            using (SqlConnection connection = new SqlConnection(_connectionString))
+            {
+                connection.Open();
+                string sql = "SELECT Id, Timestamp, EntityType, ActionType, PerformedBy, Details FROM PersistentLogs WHERE 1=1";
+                if (!string.IsNullOrEmpty(entityTypeFilter))
+                {
+                    sql += " AND EntityType = @EntityType";
+                }
+                if (!string.IsNullOrEmpty(actionTypeFilter))
+                {
+                    sql += " AND ActionType = @ActionType";
+                }
+                sql += " ORDER BY Timestamp DESC";
+
+                using (SqlCommand cmd = new SqlCommand(sql, connection))
+                {
+                    if (!string.IsNullOrEmpty(entityTypeFilter))
+                    {
+                        cmd.Parameters.AddWithValue("@EntityType", entityTypeFilter);
+                    }
+                    if (!string.IsNullOrEmpty(actionTypeFilter))
+                    {
+                        cmd.Parameters.AddWithValue("@ActionType", actionTypeFilter);
+                    }
+
+                    using (SqlDataReader reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            logs.Add(new PersistentLog
+                            {
+                                Id = Convert.ToInt32(reader["Id"]),
+                                Timestamp = Convert.ToDateTime(reader["Timestamp"]),
+                                EntityType = reader["EntityType"].ToString(),
+                                ActionType = reader["ActionType"].ToString(),
+                                PerformedBy = reader["PerformedBy"].ToString(),
+                                Details = reader["Details"].ToString()
+                            });
+                        }
+                    }
+                }
+            }
+            return logs;
+        }
+    }
+}

--- a/Web/Views/Gerenciamento/PersistentLogs.cshtml
+++ b/Web/Views/Gerenciamento/PersistentLogs.cshtml
@@ -1,0 +1,58 @@
+@model web.Models.PersistentLogViewModel
+
+@{
+    ViewData["Title"] = "Log Persistente";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<form asp-action="PersistentLogs" method="get" class="mb-4">
+    <div class="row g-3 align-items-end">
+        <div class="col-md-4">
+            <label for="entityTypeFilter" class="form-label">Filtrar por Tipo de Entidade</label>
+            <select name="entityTypeFilter" id="entityTypeFilter" class="form-select" onchange="this.form.submit()">
+                <option value="">Todos</option>
+                <option value="User" selected="@("User".Equals(Model.EntityTypeFilter))">Usuário</option>
+                <option value="Computer" selected="@("Computer".Equals(Model.EntityTypeFilter))">Computador</option>
+            </select>
+        </div>
+        <div class="col-md-4">
+            <label for="actionTypeFilter" class="form-label">Filtrar por Tipo de Ação</label>
+            <select name="actionTypeFilter" id="actionTypeFilter" class="form-select" onchange="this.form.submit()">
+                <option value="">Todas</option>
+                <option value="Create" selected="@("Create".Equals(Model.ActionTypeFilter))">Inclusão</option>
+                <option value="Update" selected="@("Update".Equals(Model.ActionTypeFilter))">Alteração</option>
+                <option value="Delete" selected="@("Delete".Equals(Model.ActionTypeFilter))">Remoção</option>
+            </select>
+        </div>
+        <div class="col-md-4">
+            <a asp-action="PersistentLogs" class="btn btn-secondary">Limpar Filtros</a>
+        </div>
+    </div>
+</form>
+
+<div class="table-responsive">
+    <table class="table table-striped table-bordered">
+        <thead class="thead-dark">
+            <tr>
+                <th>Timestamp</th>
+                <th>Tipo de Entidade</th>
+                <th>Tipo de Ação</th>
+                <th>Realizado Por</th>
+                <th>Detalhes</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in Model.Logs)
+            {
+                <tr>
+                    <td>@item.Timestamp.ToString("g")</td>
+                    <td>@item.EntityType</td>
+                    <td>@item.ActionType</td>
+                    <td>@item.PerformedBy</td>
+                    <td>@item.Details</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/Web/Views/Shared/_Layout.cshtml
+++ b/Web/Views/Shared/_Layout.cshtml
@@ -60,6 +60,10 @@
                                 <a class="nav-link text-dark" asp-area="" asp-controller="Gerenciamento"
                                     asp-action="Logs">Logs</a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-area="" asp-controller="Gerenciamento"
+                                    asp-action="PersistentLogs">Log Persistente</a>
+                            </li>
                         }
                     </ul>
                     <partial name="_LoginPartial" />

--- a/persistent_logs_schema.sql
+++ b/persistent_logs_schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE PersistentLogs (
+    Id INT PRIMARY KEY IDENTITY,
+    Timestamp DATETIME NOT NULL,
+    EntityType NVARCHAR(50) NOT NULL,
+    ActionType NVARCHAR(50) NOT NULL,
+    PerformedBy NVARCHAR(255) NOT NULL,
+    Details NVARCHAR(MAX)
+);


### PR DESCRIPTION
This commit introduces a new persistent logging feature that records the creation, update, and deletion of users and computers.

- Creates a new `PersistentLogs` table and a corresponding `PersistentLog` model to store the audit trail.
- Implements a `PersistentLogService` to handle the business logic for adding and retrieving log entries.
- Integrates the logging service into the `UsersController` and `ComputadoresController` to log all CRUD operations.
- Adds a new "Log Persistente" page, accessible only to administrators, to view and filter the logs.
- The new page provides filters for entity type (user/computer) and action type (inclusion/alteration/removal).
- Adds a navigation link to the new page in the main layout for easy access by administrators.