### PR TITLE
Fix: Invalid column name 'ColaboradorNome' error

### DIFF
--- a/Web/Controllers/PerifericosController.cs
+++ b/Web/Controllers/PerifericosController.cs
@@ -35,10 +35,10 @@ namespace Web.Controllers
                 using (SqlConnection connection = new SqlConnection(_connectionString))
                 {
                     connection.Open();
-                    string sql = "SELECT * FROM Perifericos";
+                    string sql = "SELECT p.*, c.Nome as ColaboradorNome FROM Perifericos p LEFT JOIN Colaboradores c ON p.ColaboradorCPF = c.CPF";
                     if (!string.IsNullOrEmpty(searchString))
                     {
-                        sql += " WHERE ColaboradorNome LIKE @search OR Tipo LIKE @search OR PartNumber LIKE @search";
+                        sql += " WHERE c.Nome LIKE @search OR p.Tipo LIKE @search OR p.PartNumber LIKE @search";
                     }
                     using (SqlCommand cmd = new SqlCommand(sql, connection))
                     {
@@ -53,7 +53,8 @@ namespace Web.Controllers
                                 perifericos.Add(new Periferico
                                 {
                                     PartNumber = reader["PartNumber"].ToString(),
-                                    ColaboradorNome = reader["ColaboradorNome"].ToString(),
+                                    ColaboradorCPF = reader["ColaboradorCPF"] as string,
+                                    ColaboradorNome = reader["ColaboradorNome"] as string,
                                     Tipo = reader["Tipo"].ToString(),
                                     DataEntrega = reader["DataEntrega"] != DBNull.Value ? Convert.ToDateTime(reader["DataEntrega"]) : (DateTime?)null
                                 });
@@ -73,7 +74,7 @@ namespace Web.Controllers
         [Authorize(Roles = "Admin")]
         public IActionResult Create()
         {
-            ViewData["ColaboradorNome"] = new SelectList(GetColaboradores(), "Nome", "Nome");
+            ViewData["Colaboradores"] = new SelectList(GetColaboradores(), "CPF", "Nome");
             return View();
         }
 
@@ -90,11 +91,11 @@ namespace Web.Controllers
                     using (SqlConnection connection = new SqlConnection(_connectionString))
                     {
                         connection.Open();
-                        string sql = "INSERT INTO Perifericos (PartNumber, ColaboradorNome, Tipo, DataEntrega) VALUES (@PartNumber, @ColaboradorNome, @Tipo, @DataEntrega)";
+                        string sql = "INSERT INTO Perifericos (PartNumber, ColaboradorCPF, Tipo, DataEntrega) VALUES (@PartNumber, @ColaboradorCPF, @Tipo, @DataEntrega)";
                         using (SqlCommand cmd = new SqlCommand(sql, connection))
                         {
                             cmd.Parameters.AddWithValue("@PartNumber", periferico.PartNumber);
-                            cmd.Parameters.AddWithValue("@ColaboradorNome", (object)periferico.ColaboradorNome ?? DBNull.Value);
+                            cmd.Parameters.AddWithValue("@ColaboradorCPF", (object)periferico.ColaboradorCPF ?? DBNull.Value);
                             cmd.Parameters.AddWithValue("@Tipo", periferico.Tipo);
                             cmd.Parameters.AddWithValue("@DataEntrega", (object)periferico.DataEntrega ?? DBNull.Value);
                             cmd.ExecuteNonQuery();
@@ -109,7 +110,7 @@ namespace Web.Controllers
                     ModelState.AddModelError(string.Empty, "Ocorreu um erro ao criar o periférico.");
                 }
             }
-            ViewData["ColaboradorNome"] = new SelectList(GetColaboradores(), "Nome", "Nome", periferico.ColaboradorNome);
+            ViewData["Colaboradores"] = new SelectList(GetColaboradores(), "CPF", "Nome", periferico.ColaboradorCPF);
             return View(periferico);
         }
 
@@ -119,7 +120,7 @@ namespace Web.Controllers
         {
             Periferico periferico = FindPerifericoById(id);
             if (periferico == null) return NotFound();
-            ViewData["ColaboradorNome"] = new SelectList(GetColaboradores(), "Nome", "Nome", periferico.ColaboradorNome);
+            ViewData["Colaboradores"] = new SelectList(GetColaboradores(), "CPF", "Nome", periferico.ColaboradorCPF);
             return View(periferico);
         }
 
@@ -138,11 +139,11 @@ namespace Web.Controllers
                     using (SqlConnection connection = new SqlConnection(_connectionString))
                     {
                         connection.Open();
-                        string sql = "UPDATE Perifericos SET ColaboradorNome = @ColaboradorNome, Tipo = @Tipo, DataEntrega = @DataEntrega WHERE PartNumber = @PartNumber";
+                        string sql = "UPDATE Perifericos SET ColaboradorCPF = @ColaboradorCPF, Tipo = @Tipo, DataEntrega = @DataEntrega WHERE PartNumber = @PartNumber";
                         using (SqlCommand cmd = new SqlCommand(sql, connection))
                         {
                             cmd.Parameters.AddWithValue("@PartNumber", periferico.PartNumber);
-                            cmd.Parameters.AddWithValue("@ColaboradorNome", (object)periferico.ColaboradorNome ?? DBNull.Value);
+                            cmd.Parameters.AddWithValue("@ColaboradorCPF", (object)periferico.ColaboradorCPF ?? DBNull.Value);
                             cmd.Parameters.AddWithValue("@Tipo", periferico.Tipo);
                             cmd.Parameters.AddWithValue("@DataEntrega", (object)periferico.DataEntrega ?? DBNull.Value);
                             cmd.ExecuteNonQuery();
@@ -157,7 +158,7 @@ namespace Web.Controllers
                     ModelState.AddModelError(string.Empty, "Ocorreu um erro ao editar o periférico.");
                 }
             }
-            ViewData["ColaboradorNome"] = new SelectList(GetColaboradores(), "Nome", "Nome", periferico.ColaboradorNome);
+            ViewData["Colaboradores"] = new SelectList(GetColaboradores(), "CPF", "Nome", periferico.ColaboradorCPF);
             return View(periferico);
         }
 
@@ -209,7 +210,7 @@ namespace Web.Controllers
             using (SqlConnection connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
-                string sql = "SELECT * FROM Perifericos WHERE PartNumber = @PartNumber";
+                string sql = "SELECT p.*, c.Nome AS ColaboradorNome FROM Perifericos p LEFT JOIN Colaboradores c ON p.ColaboradorCPF = c.CPF WHERE p.PartNumber = @PartNumber";
                 using (SqlCommand cmd = new SqlCommand(sql, connection))
                 {
                     cmd.Parameters.AddWithValue("@PartNumber", id);
@@ -220,7 +221,8 @@ namespace Web.Controllers
                             periferico = new Periferico
                             {
                                 PartNumber = reader["PartNumber"].ToString(),
-                                ColaboradorNome = reader["ColaboradorNome"].ToString(),
+                                ColaboradorCPF = reader["ColaboradorCPF"] as string,
+                                ColaboradorNome = reader["ColaboradorNome"] as string,
                                 Tipo = reader["Tipo"].ToString(),
                                 DataEntrega = reader["DataEntrega"] != DBNull.Value ? Convert.ToDateTime(reader["DataEntrega"]) : (DateTime?)null
                             };

--- a/Web/Models/Monitor.cs
+++ b/Web/Models/Monitor.cs
@@ -12,12 +12,14 @@ namespace Web.Models
         public string PartNumber { get; set; }
 
         [Display(Name = "Colaborador")]
-        [ValidateNever]
-        public string? ColaboradorNome { get; set; }
+        public string? ColaboradorCPF { get; set; }
 
-        [ForeignKey("ColaboradorNome")]
+        [ForeignKey("ColaboradorCPF")]
         [ValidateNever]
         public virtual Colaborador? Colaborador { get; set; }
+
+        [NotMapped]
+        public string? ColaboradorNome { get; set; }
 
         [StringLength(50)]
         [ValidateNever]

--- a/Web/Models/Periferico.cs
+++ b/Web/Models/Periferico.cs
@@ -13,12 +13,14 @@ namespace Web.Models
         public string PartNumber { get; set; }
 
         [Display(Name = "Colaborador")]
-        [ValidateNever]
-        public string? ColaboradorNome { get; set; }
+        public string? ColaboradorCPF { get; set; }
 
-        [ForeignKey("ColaboradorNome")]
+        [ForeignKey("ColaboradorCPF")]
         [ValidateNever]
         public virtual Colaborador? Colaborador { get; set; }
+
+        [NotMapped]
+        public string? ColaboradorNome { get; set; }
 
         [Required(ErrorMessage = "O Tipo é obrigatório.")]
         [StringLength(50)]


### PR DESCRIPTION
This commit resolves a `SqlException` caused by an invalid column name 'ColaboradorNome' in the `Perifericos` and `Monitores` tables.

The error was due to a mismatch between the application's data models and the database schema. The code was attempting to use `ColaboradorNome` as a foreign key, whereas the correct foreign key is `ColaboradorCPF`.

The following changes have been made:
- Updated the `Periferico` and `Monitor` models to use `ColaboradorCPF` as the foreign key to the `Colaboradores` table.
- Added a `[NotMapped]` attribute to the `ColaboradorNome` property in these models, so it is not mapped to the database.
- Modified the `PerifericosController` and `MonitoresController` to use `ColaboradorCPF` in all SQL queries (INSERT, UPDATE, SELECT).
- Updated the SELECT queries in these controllers to use a `LEFT JOIN` with the `Colaboradores` table to fetch the `ColaboradorNome` for display purposes.
- Updated the `ViewData` for dropdown lists in the views to use `CPF` as the value and `Nome` as the text, consistent with other controllers.