### PR TITLE
Add winget package ID to installed programs collection

### DIFF
--- a/Coleta/Program.cs
+++ b/Coleta/Program.cs
@@ -265,12 +265,66 @@ namespace coleta
                                             }
                                             else if (comandoRemoto == "get_installed_programs")
                                             {
-                                                Console.WriteLine($"[INFO] Coletando programas instalados (wmic / PowerShell)...");
-                                                // Usamos PowerShell porque winget às vezes requer interação de usuário ou falha em background
-                                                // Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*
-                                                string script = @"Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*, HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -ne $null } | Select-Object DisplayName, DisplayVersion, Publisher | ConvertTo-Json -Compress";
+                                                Console.WriteLine($"[INFO] Coletando programas instalados (wmic / PowerShell + winget)...");
+                                                string script = @"
+$regProgs = Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*, HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -ne $null } | Select-Object DisplayName, DisplayVersion, Publisher
+$wingetOut = winget list --accept-source-agreements --accept-package-agreements
+$wingetMap = @{}
+$dashLineIdx = -1
+if ($wingetOut -ne $null) {
+    for ($i=0; $i -lt $wingetOut.Count; $i++) {
+        if ($wingetOut[$i] -match '^-+$') { $dashLineIdx = $i; break }
+    }
+}
+if ($dashLineIdx -gt 0) {
+    $header = $wingetOut[$dashLineIdx - 1]
+    $cols = $header -split '\s{2,}'
+    if ($cols.Count -ge 3) {
+        $idIdx = $header.IndexOf($cols[1])
+        $versionIdx = $header.IndexOf($cols[2])
+        for ($i = $dashLineIdx + 1; $i -lt $wingetOut.Count; $i++) {
+            $line = $wingetOut[$i]
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $name = if ($line.Length -gt $idIdx) { $line.Substring(0, $idIdx).TrimEnd() } else { $line.TrimEnd() }
+            $id = if ($line.Length -gt $versionIdx) { $line.Substring($idIdx, $versionIdx - $idIdx).TrimEnd() } elseif ($line.Length -gt $idIdx) { $line.Substring($idIdx).TrimEnd() } else { """" }
+            $version = if ($line.Length -gt $versionIdx) { $line.Substring($versionIdx).TrimEnd() -replace '\s{2,}.*','' } else { """" }
+            if ($name) { $wingetMap[$name] = @{ Id = $id; Version = $version } }
+        }
+    }
+}
 
-                                                string resultado = Comandos.ExecutarComando($"powershell -NoProfile -ExecutionPolicy Bypass -Command \"{script}\"");
+$results = @()
+$processedNames = @{}
+foreach ($regProg in $regProgs) {
+    $name = $regProg.DisplayName
+    if (-not $processedNames.ContainsKey($name)) {
+        $id = """"
+        if ($wingetMap.ContainsKey($name)) { $id = $wingetMap[$name].Id }
+        $results += [PSCustomObject]@{
+            DisplayName = $name
+            Id = $id
+            DisplayVersion = $regProg.DisplayVersion
+            Publisher = $regProg.Publisher
+        }
+        $processedNames[$name] = $true
+    }
+}
+
+foreach ($key in $wingetMap.Keys) {
+    if (-not $processedNames.ContainsKey($key)) {
+        $results += [PSCustomObject]@{
+            DisplayName = $key
+            Id = $wingetMap[$key].Id
+            DisplayVersion = $wingetMap[$key].Version
+            Publisher = """"
+        }
+    }
+}
+$results | ConvertTo-Json -Compress
+";
+                                                byte[] scriptBytes = System.Text.Encoding.Unicode.GetBytes(script);
+                                                string encodedCommand = Convert.ToBase64String(scriptBytes);
+                                                string resultado = Comandos.ExecutarComando($"powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand {encodedCommand}");
                                                 await writer.WriteLineAsync(resultado);
                                                 Console.WriteLine($"[INFO] Lista de programas enviada.");
                                             }

--- a/Web/Controllers/ProgramasController.cs
+++ b/Web/Controllers/ProgramasController.cs
@@ -65,6 +65,7 @@ namespace Web.Controllers
                                 Nome = reader["Nome"].ToString(),
                                 Versao = reader["Versao"] != DBNull.Value ? reader["Versao"].ToString() : "",
                                 Desenvolvedor = reader["Desenvolvedor"] != DBNull.Value ? reader["Desenvolvedor"].ToString() : "",
+                                PacoteId = reader["PacoteId"] != DBNull.Value ? reader["PacoteId"].ToString() : "",
                                 DataColeta = Convert.ToDateTime(reader["DataColeta"]),
                                 Hostname = reader["Hostname"].ToString()
                             });
@@ -136,6 +137,7 @@ namespace Web.Controllers
                                 programas.Add(new ProgramaInfo
                                 {
                                     DisplayName = element.GetProperty("DisplayName").GetString(),
+                                    Id = element.TryGetProperty("Id", out var id) ? id.GetString() : "",
                                     DisplayVersion = element.TryGetProperty("DisplayVersion", out var v) ? v.GetString() : "",
                                     Publisher = element.TryGetProperty("Publisher", out var p) ? p.GetString() : ""
                                 });
@@ -146,6 +148,7 @@ namespace Web.Controllers
                             programas.Add(new ProgramaInfo
                             {
                                 DisplayName = jsonDoc.RootElement.GetProperty("DisplayName").GetString(),
+                                Id = jsonDoc.RootElement.TryGetProperty("Id", out var id) ? id.GetString() : "",
                                 DisplayVersion = jsonDoc.RootElement.TryGetProperty("DisplayVersion", out var v) ? v.GetString() : "",
                                 Publisher = jsonDoc.RootElement.TryGetProperty("Publisher", out var p) ? p.GetString() : ""
                             });
@@ -170,12 +173,13 @@ namespace Web.Controllers
                                 {
                                     using (var cmd = connection.CreateCommand())
                                     {
-                                        cmd.CommandText = "INSERT INTO ProgramasInstalados (ComputadorMAC, Nome, Versao, Desenvolvedor, DataColeta) VALUES (@MAC, @Nome, @Versao, @Desenvolvedor, @DataColeta)";
+                                        cmd.CommandText = "INSERT INTO ProgramasInstalados (ComputadorMAC, Nome, Versao, Desenvolvedor, PacoteId, DataColeta) VALUES (@MAC, @Nome, @Versao, @Desenvolvedor, @PacoteId, @DataColeta)";
                                         var p1 = cmd.CreateParameter(); p1.ParameterName = "@MAC"; p1.Value = mac; cmd.Parameters.Add(p1);
                                         var p2 = cmd.CreateParameter(); p2.ParameterName = "@Nome"; p2.Value = p.DisplayName; cmd.Parameters.Add(p2);
                                         var p3 = cmd.CreateParameter(); p3.ParameterName = "@Versao"; p3.Value = p.DisplayVersion ?? (object)DBNull.Value; cmd.Parameters.Add(p3);
                                         var p4 = cmd.CreateParameter(); p4.ParameterName = "@Desenvolvedor"; p4.Value = p.Publisher ?? (object)DBNull.Value; cmd.Parameters.Add(p4);
-                                        var p5 = cmd.CreateParameter(); p5.ParameterName = "@DataColeta"; p5.Value = dataColeta; cmd.Parameters.Add(p5);
+                                        var p5 = cmd.CreateParameter(); p5.ParameterName = "@PacoteId"; p5.Value = p.Id ?? (object)DBNull.Value; cmd.Parameters.Add(p5);
+                                        var p6 = cmd.CreateParameter(); p6.ParameterName = "@DataColeta"; p6.Value = dataColeta; cmd.Parameters.Add(p6);
                                         cmd.ExecuteNonQuery();
                                     }
                                 }
@@ -204,6 +208,7 @@ namespace Web.Controllers
         private class ProgramaInfo
         {
             public string DisplayName { get; set; }
+            public string Id { get; set; }
             public string DisplayVersion { get; set; }
             public string Publisher { get; set; }
         }

--- a/Web/Models/ProgramaInstalado.cs
+++ b/Web/Models/ProgramaInstalado.cs
@@ -9,6 +9,7 @@ namespace Web.Models
         public string Nome { get; set; }
         public string Versao { get; set; }
         public string Desenvolvedor { get; set; }
+        public string PacoteId { get; set; }
         public DateTime DataColeta { get; set; }
         public string Hostname { get; set; } // Propriedade de visualização
     }

--- a/Web/Services/DatabaseService.cs
+++ b/Web/Services/DatabaseService.cs
@@ -100,6 +100,8 @@ namespace Web.Services
                         "ALTER TABLE Computadores ADD COLUMN ProcessadorTemperatura TEXT;",
 
                         "ALTER TABLE Computadores ADD COLUMN BateriaWearLevel TEXT;",
+
+                        "ALTER TABLE ProgramasInstalados ADD COLUMN PacoteId TEXT;",
                         "ALTER TABLE Computadores ADD COLUMN TempoAtividade TEXT;",
                         "ALTER TABLE Computadores ADD COLUMN Localizacao TEXT;",
 

--- a/Web/Views/Programas/Index.cshtml
+++ b/Web/Views/Programas/Index.cshtml
@@ -44,6 +44,7 @@
                             <th>Computador</th>
                             <th>MAC</th>
                             <th>Programa</th>
+                            <th>ID do Pacote</th>
                             <th>Versão</th>
                             <th>Desenvolvedor</th>
                             <th>Data da Coleta</th>
@@ -56,6 +57,7 @@
                                 <td>@item.Hostname</td>
                                 <td>@item.ComputadorMAC</td>
                                 <td>@item.Nome</td>
+                                <td>@item.PacoteId</td>
                                 <td>@item.Versao</td>
                                 <td>@item.Desenvolvedor</td>
                                 <td>@item.DataColeta.ToString("dd/MM/yyyy HH:mm")</td>

--- a/Web/schema_main.sql
+++ b/Web/schema_main.sql
@@ -67,6 +67,7 @@ CREATE TABLE IF NOT EXISTS ProgramasInstalados (
     Nome TEXT NOT NULL,
     Versao TEXT,
     Desenvolvedor TEXT,
+    PacoteId TEXT,
     DataColeta TEXT NOT NULL,
     FOREIGN KEY (ComputadorMAC) REFERENCES Computadores(MAC) ON DELETE CASCADE
 );


### PR DESCRIPTION
Resolves issue by adding the winget package ID (e.g. "Google.Chrome") to the collected program information so administrators can easily identify and reinstall/uninstall software using the exact package ID.

---
*PR created automatically by Jules for task [4489420306281954540](https://jules.google.com/task/4489420306281954540) started by @Lucas-Cardoso-Gomes*